### PR TITLE
Lowercase the repository name to comply with github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,5 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
         registry: docker.pkg.github.com
-        repository: EventStore/es-gencert-cli/es-gencert-cli
+        repository: eventstore/es-gencert-cli/es-gencert-cli
         tag_with_ref: true


### PR DESCRIPTION
Fixes the following when we attempted to tag 1.0.1
```
invalid argument "docker.pkg.github.com/EventStore/es-gencert-cli/es-gencert-cli:1.0.1" for "-t, --tag" flag: invalid reference format: repository name must be lowercase
```