### PR TITLE
Added: command line option to configure certificate common name (DEV-82)

### DIFF
--- a/certificates/create_node.go
+++ b/certificates/create_node.go
@@ -292,6 +292,7 @@ Options:
   -out                        The output directory (default: ./nodeX where X is an auto-generated number)
   -ip-addresses               Comma-separated list of IP addresses of the node
   -dns-names                  Comma-separated list of DNS names of the node
+  -common-name                The certificate subject common name
 
   At least one IP address or DNS name needs to be specified
 `


### PR DESCRIPTION
- Provide a command line option to configure certificate's common name
- the default common name will be "eventstoredb-node" as before

Related [ticket](https://github.com/EventStore/es-gencert-cli/issues/14)