### PR TITLE
add working dir to docker image [DB-151]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,11 @@ RUN adduser \
     --no-create-home \
     --uid "1000" \
     "eventstore" && \
-chown eventstore:eventstore /app \
+    chown eventstore:eventstore /app \
     --recursive
 
 USER eventstore
 ENV PATH=$PATH:/app
+WORKDIR /tmp
 ENTRYPOINT ["/app/es-gencert-cli"]
 CMD []


### PR DESCRIPTION
Currently, a run without options fails with permission errors, as the default working dir is `/`:
![image](https://github.com/EventStore/es-gencert-cli/assets/11350169/8eccd7cb-ebfd-4011-b315-770ff733a306)

Setting the working dir to `/tmp` allows it to function without permission errors:
![image](https://github.com/EventStore/es-gencert-cli/assets/11350169/f1a7c0b8-9a90-4d02-93f7-451cc8467d5c)

This is useful for simplifying bootstrapping configs, e.g. if an external config is mounting a volume into `/tmp`.