### PR TITLE
Override existing certs when generating from yaml (DEV-77)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ _testmain.go
 .idea/
 binaries/
 ca/
+
+es-gencert-cli
+certs.yml

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ certificates:
   ca-certs:
     - out: "./root_ca"
     - out: "./intermediate_ca"
-      cert-path: "./root_ca/ca.crt"
-      key-path: "./root_ca/ca.key"
+      ca-certificate: "./root_ca/ca.crt"
+      ca-key: "./root_ca/ca.key"
       days: 5
   node-certs:
     - out: "./node1"

--- a/certificates/common.go
+++ b/certificates/common.go
@@ -1,12 +1,23 @@
 package certificates
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
+	"fmt"
 	"math/big"
+	"os"
+	"path"
+	"text/tabwriter"
 )
 
 const defaultKeySize = 2048
+
+const forceOption = "Force overwrite of existing files without prompting"
+
+const (
+	ErrFileExists = "Error: Existing files would be overwritten. Use -force to proceed"
+)
 
 func generateSerialNumber(bits uint) (*big.Int, error) {
 	maxValue := new(big.Int).Lsh(big.NewInt(1), bits)
@@ -24,4 +35,53 @@ func generateKeyIDFromRSAPublicKey(N *big.Int, e int) []byte {
 	h := sha256.New()
 	h.Write(x.Bytes())
 	return h.Sum(nil)
+}
+
+func writeFileWithDir(filePath string, data []byte, perm os.FileMode) error {
+	dir := path.Dir(filePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filePath, data, perm)
+}
+
+func writeHelpOption(w *tabwriter.Writer, title string, description string) {
+	fmt.Fprintf(w, "\t-%s\t%s\n", title, description)
+}
+
+func writeCACertAndKey(outputDir string, fileName string, certPem, privateKeyPem *bytes.Buffer, force bool) error {
+	certFile := path.Join(outputDir, fileName+".crt")
+	keyFile := path.Join(outputDir, fileName+".key")
+
+	if force {
+		if _, err := os.Stat(certFile); err == nil {
+			if err = os.Chmod(certFile, 0644); err != nil {
+				return fmt.Errorf("error making %s writable: %s", certFile, err.Error())
+			}
+		}
+		if _, err := os.Stat(keyFile); err == nil {
+			if err = os.Chmod(keyFile, 0600); err != nil {
+				return fmt.Errorf("error making %s writable: %s", keyFile, err.Error())
+			}
+		}
+	}
+
+	err := writeFileWithDir(certFile, certPem.Bytes(), 0444)
+	if err != nil {
+		return fmt.Errorf("error writing CA certificate to %s: %s", certFile, err.Error())
+	}
+
+	err = writeFileWithDir(keyFile, privateKeyPem.Bytes(), 0400)
+	if err != nil {
+		return fmt.Errorf("error writing CA's private key to %s: %s", keyFile, err.Error())
+	}
+
+	return nil
+}
+
+func fileExists(path string, force bool) bool {
+	if _, err := os.Stat(path); !os.IsNotExist(err) && !force {
+		return true
+	}
+	return false
 }

--- a/certificates/create_ca_test.go
+++ b/certificates/create_ca_test.go
@@ -10,33 +10,72 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGenerateCACertificate(t *testing.T) {
+func setupTestEnvironment(t *testing.T, override bool) (years int, days int, outputDir string, caCert *x509.Certificate, caKey *rsa.PrivateKey) {
+	years = 1
+	days = 0
+	outputDir = "./ca"
+	caCert = nil
+	caKey = nil
 
-	t.Run("nominal-case", func(t *testing.T) {
-		years := 1
-		days := 0
-		outputDir := "./ca"
-		var caCert *x509.Certificate
-		var caKey *rsa.PrivateKey
-
-		// Clean up from previous runs
+	t.Cleanup(func() {
 		os.RemoveAll(outputDir)
-
-		certificateError := generateCACertificate(years, days, outputDir, caCert, caKey)
-
-		certFilePath := path.Join(outputDir, "ca.crt")
-		keyFilePath := path.Join(outputDir, "ca.key")
-
-		_, certPathError := os.Stat(certFilePath)
-		_, keyPathError := os.Stat(keyFilePath)
-
-		assert.NoError(t, certificateError)
-		assert.False(t, os.IsNotExist(certPathError))
-		assert.False(t, os.IsNotExist(keyPathError))
-
-		// Clean up
-		os.RemoveAll(outputDir)
-
 	})
 
+	return
+}
+
+func testGenerateCACertificate(t *testing.T, years int, days int, outputDir string, caCert *x509.Certificate, caKey *rsa.PrivateKey, force bool) {
+	err := generateCACertificate(years, days, outputDir, caCert, caKey, force)
+	assert.NoError(t, err, "Expected no error in nominal case")
+
+	certFilePath := path.Join(outputDir, "ca.crt")
+	keyFilePath := path.Join(outputDir, "ca.key")
+
+	certFile, err := readCertificateFromFile(certFilePath)
+	assert.NoError(t, err)
+	keyFile, err := readRSAKeyFromFile(keyFilePath)
+	assert.NoError(t, err)
+
+	err = generateCACertificate(years, days, outputDir, caCert, caKey, force)
+	if !force {
+		assert.Error(t, err, "Expected an error when directory exists and override is false")
+	} else {
+		assert.NoError(t, err, "Expected no error when directory exists and override is true")
+	}
+
+	certFileAfter, err := readCertificateFromFile(certFilePath)
+	assert.NoError(t, err)
+	keyFileAfter, err := readRSAKeyFromFile(keyFilePath)
+	assert.NoError(t, err)
+
+	if !force {
+		assert.Equal(t, certFile, certFileAfter, "Expected CA certificate to be the same")
+		assert.Equal(t, keyFile, keyFileAfter, "Expected CA key to be the same")
+	} else {
+		assert.NotEqual(t, certFile, certFileAfter, "Expected CA certificate to be different")
+		assert.NotEqual(t, keyFile, keyFileAfter, "Expected CA key to be different")
+	}
+}
+
+func TestGenerateCACertificate(t *testing.T) {
+	t.Run("nominal-case", func(t *testing.T) {
+		years, days, outputDir, caCert, caKey := setupTestEnvironment(t, false)
+
+		err := generateCACertificate(years, days, outputDir, caCert, caKey, false)
+
+		assert.NoError(t, err, "Expected no error in nominal case")
+
+		assert.FileExists(t, path.Join(outputDir, "ca.crt"), "CA certificate should exist")
+		assert.FileExists(t, path.Join(outputDir, "ca.key"), "CA key should exist")
+	})
+
+	t.Run("directory-exists", func(t *testing.T) {
+		years, days, outputDir, caCert, caKey := setupTestEnvironment(t, false)
+		testGenerateCACertificate(t, years, days, outputDir, caCert, caKey, false)
+	})
+
+	t.Run("directory-exists-force", func(t *testing.T) {
+		years, days, outputDir, caCert, caKey := setupTestEnvironment(t, true)
+		testGenerateCACertificate(t, years, days, outputDir, caCert, caKey, true)
+	})
 }

--- a/certificates/create_certs.go
+++ b/certificates/create_certs.go
@@ -1,13 +1,18 @@
 package certificates
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
-	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v3"
 	"os"
+	"path"
 	"reflect"
 	"strings"
+	"sync"
+	"text/tabwriter"
+
+	"github.com/mitchellh/cli"
+	"gopkg.in/yaml.v3"
 )
 
 type CreateCertificates struct {
@@ -16,6 +21,7 @@ type CreateCertificates struct {
 
 type CreateCertificateArguments struct {
 	ConfigPath string
+	Force      bool `yaml:"force"`
 }
 
 type Config struct {
@@ -30,6 +36,8 @@ func (c *CreateCertificates) Run(args []string) int {
 	flags := flag.NewFlagSet("create_certs", flag.ContinueOnError)
 	flags.Usage = func() { c.Ui.Info(c.Help()) }
 	flags.StringVar(&arguments.ConfigPath, "config-file", "./certs.yml", "The config yml file")
+	flags.BoolVar(&arguments.Force, "force", false, "Force overwrite of existing files without prompting")
+
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
@@ -45,16 +53,59 @@ func (c *CreateCertificates) Run(args []string) int {
 		return 1
 	}
 
-	if c.generateCaCerts(config) != 0 || c.generateNodes(config) != 0 {
+	if err := c.checkPaths(config, arguments.Force); err {
+		c.Ui.Error(ErrFileExists)
+		return 1
+	}
+
+	if c.generateCaCerts(config, arguments.Force) != 0 || c.generateNodes(config, arguments.Force) != 0 {
 		return 1
 	}
 
 	return 0
-
 }
 
-func (c *CreateCertificates) generateNodes(config Config) int {
+func (c *CreateCertificates) checkPaths(config Config, force bool) bool {
+	// If any certs file exists and the force flag isn't provided, it returns an
+	// error. Otherwise, it returns false, indicating that certificate generation
+	// can proceed safely.
+
+	var errorMutex sync.Mutex
+	var error bool
+	var wg sync.WaitGroup
+
+	checkFile := func(filePath string) {
+		defer wg.Done()
+		if fileExists(filePath, force) {
+			errorMutex.Lock()
+			error = true
+			errorMutex.Unlock()
+		}
+	}
+
+	// Check CA certificate and key paths
+	for _, caCert := range config.Certificates.CaCerts {
+		wg.Add(2)
+		go checkFile(caCert.CACertificatePath)
+		go checkFile(caCert.CAKeyPath)
+	}
+
+	// Check Node certificate and key paths
 	for _, node := range config.Certificates.Nodes {
+		wg.Add(4)
+		go checkFile(node.CACertificatePath)
+		go checkFile(node.CAKeyPath)
+		go checkFile(path.Join(node.OutputDir, "node.crt"))
+		go checkFile(path.Join(node.OutputDir, "node.key"))
+	}
+
+	wg.Wait()
+	return error
+}
+
+func (c *CreateCertificates) generateNodes(config Config, force bool) int {
+	for _, node := range config.Certificates.Nodes {
+		node.Force = force
 		createNode := CreateNode{
 			Ui: &cli.ColoredUi{
 				Ui:          c.Ui,
@@ -68,18 +119,20 @@ func (c *CreateCertificates) generateNodes(config Config) int {
 	return 0
 }
 
-func (c *CreateCertificates) generateCaCerts(config Config) int {
-	for _, ca := range config.Certificates.CaCerts {
-		createCa := CreateCA{
-			Ui: &cli.ColoredUi{
-				Ui:          c.Ui,
-				OutputColor: cli.UiColorBlue,
-			},
-		}
-		if createCa.Run(toArguments(ca)) != 0 {
+func (c *CreateCertificates) generateCaCerts(config Config, force bool) int {
+	coloredUI := &cli.ColoredUi{
+		Ui:          c.Ui,
+		OutputColor: cli.UiColorBlue,
+	}
+
+	for _, caCert := range config.Certificates.CaCerts {
+		caCert.Force = force
+		caCreator := CreateCA{Ui: coloredUI}
+		if caCreator.Run(toArguments(caCert)) != 0 {
 			return 1
 		}
 	}
+
 	return 0
 }
 
@@ -88,22 +141,36 @@ func toArguments(config interface{}) []string {
 	fields := reflect.ValueOf(config)
 	for i := 0; i < fields.NumField(); i++ {
 		key := reflect.TypeOf(config).Field(i).Tag.Get("yaml")
-		value := fmt.Sprintf("%v", fields.Field(i).Interface())
-		if len(value) > 0 {
-			args.WriteString(fmt.Sprintf("-%s %s ", key, value))
+		val := fields.Field(i).Interface()
+		if fields.Field(i).Kind() == reflect.Bool {
+			if val.(bool) {
+				args.WriteString(fmt.Sprintf("-%s ", key))
+			}
+		} else {
+			value := fmt.Sprintf("%v", val)
+			if len(value) > 0 {
+				args.WriteString(fmt.Sprintf("-%s %s ", key, value))
+			}
 		}
 	}
 	return strings.Fields(args.String())
 }
 
 func (c *CreateCertificates) Help() string {
-	helpText := `
-Usage: create_certs [options]
-  Generate ca and node Certificates from an yml configuration file.
-Options:
-  -config-file    the path to the yml config file
-`
-	return strings.TrimSpace(helpText)
+	var buffer bytes.Buffer
+
+	w := tabwriter.NewWriter(&buffer, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintln(w, "Usage: create_certs [options]")
+	fmt.Fprintln(w, "Generate ca and node Certificates from an yml configuration file.")
+	fmt.Fprintln(w, "Options:")
+
+	writeHelpOption(w, "config-file", "The path to the yml config file.")
+	writeHelpOption(w, "force", forceOption)
+
+	w.Flush()
+
+	return strings.TrimSpace(buffer.String())
 }
 
 func (c *CreateCertificates) Synopsis() string {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.14
 require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/mitchellh/cli v1.1.1
-	github.com/stretchr/testify v1.8.4 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	github.com/stretchr/testify v1.8.4
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -23,7 +23,6 @@ github.com/posener/complete v1.1.1 h1:ccV59UEOTzVDnDUEFdT95ZzHVZ+5+158q8+SJb2QV5
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -31,6 +30,7 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc h1:MeuS1UDyZyFH++6vVy44PuufTeFF0d0nfI6XB87YGSk=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Fix: [https://github.com/EventStore/es-gencert-cli/issues/18](https://github.com/EventStore/es-gencert-cli/issues/18)
Remove the check for existing folder error.
Add override option, when set to true will override the existing cert