### PR TITLE
Fix naming and publishing (DB-417)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Build
 
+permissions:
+  contents: write
+  packages: write
+
 on:
   pull_request:
   push:
@@ -55,7 +59,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            eventstore/es-gencert-cli/es-gencert-cli
+            ghcr.io/eventstore/es-gencert-cli
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -82,6 +86,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ghcr.io/${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,7 @@ archives:
     name_template: >-
       {{- .ProjectName }}_
       {{- .Version }}_
-      {{- title .Os }}_
+      {{- title .Os }}-
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}


### PR DESCRIPTION
Fixed: The `1.2.0` release has slightly different asset names.
Fixed: Push the `es-gencert-cli` container to the right registry (`ghcr.io`) with appropriate permissions.

Tested in fork https://github.com/pvanbuijtene/es-gencert-cli/actions.